### PR TITLE
Added vocabulary and manufacturer information to vocabulary page

### DIFF
--- a/_includes/tablet.html
+++ b/_includes/tablet.html
@@ -53,10 +53,10 @@
         <th>Specs</th>
         <td>
             {{page.working_area.width}}&Prime;&times;{{page.working_area.height}}&Prime;,
-            {{page.working_area.resolution}} [LPI]({{ site.baseurl }}/support/misc/vocabulary/#lines-per-inch "Lines per inch"){% unless page.report_rate == null %},
-            {{page.report_rate}} [RPS]({{ site.baseurl }}/support/misc/vocabulary/#reports-per-second "Reports per second")
+            {{page.working_area.resolution}} <a href="{{ site.baseurl }}/support/misc/vocabulary/#lpi" title="Lines per inch">LPI</a>{% unless page.report_rate == null %},
+            {{page.report_rate}} <a href="{{ site.baseurl }}/support/misc/vocabulary/#rps" title="Reports per second">RPS</a>
             {% endunless %},
-            {{page.pen.pressure_levels}} [PL]({{ site.baseurl }}/support/misc/vocabulary/#pressure-levels "Pressure Levels"){% if page.pen.tilt_detection %},
+            {{page.pen.pressure_levels}} <a href="{{ site.baseurl }}/support/misc/vocabulary/#pl" title="Pressure Levels">PL</a>{% if page.pen.tilt_detection %},
                 tilt-sensitive
             {% endif %}{% unless page.mouse == null %},
                 {{page.mouse}} mouse

--- a/support/index.md
+++ b/support/index.md
@@ -28,6 +28,11 @@ Troubleshooting
 [2]: http://sourceforge.net/p/digimend/mailman/digimend-users/
 [3]: https://lists.sourceforge.net/lists/listinfo/digimend-users
 
+Miscellaneous
+-------------
+
+[Vocabulary](misc/vocabulary)
+
 Maillist
 --------
 We maintain a general user support maillist at

--- a/support/misc/vocabulary/index.md
+++ b/support/misc/vocabulary/index.md
@@ -1,30 +1,12 @@
 ---
 title: Vocabulary
 ---
-Manufacturers
-=============
 
-KYE Systems Corporation
------------------------
+Huion
+-----
 
-[KYE Systems Corporation](http://www.kyecom.com/) is a DMS (design and
-manufacturing service) company specializing mostly in HID (Human
-Interface Device) devices, including graphics tablets. Established in
-1983 and based in Taiwan, the company sells graphics tablets under its
-[Genius](http://www.geniusnet.com/) brand name. Genius-branded tablets
-also include rebranded UC-Logic and Waltop tablets.
-
-### Cooperation
-
-An attempt to contact KYE was done in the beginning of 2012, using the
-"contact us" form on their web-site. A message was sent asking for
-tablet samples and information. As of March 2012 no reply was received.
-
-Shenzhen Huion Animation Technology Co., LTD
---------------------------------------------
-
-[Shenzhen Huion Animation Technology Co.,
-LTD](http://www.huion-tablet.com) is an enterprise which designs and
+[Huion (Shenzhen Huion Animation Technology Co.,
+LTD)](http://www.huion-tablet.com) is an enterprise which designs and
 manufactures animation products and other handwritten input digitizer
 products. Huion's main product line includes the USB Pen Tablet,
 Wireless Pen Tablet, Signature Pad, Pen Tablet Monitor and LED Tracing
@@ -41,47 +23,29 @@ mentioning that a driver exists for Linux 3.0 but didn't specify if it
 has been ever publicly released nor provided any instructions how such
 driver could be obtained.
 
-UC-Logic Technology Corporation
--------------------------------
+KYE
+---
 
-[UC-Logic Technology Corporation](http://www.uc-logic.com/) is an OEM
-(Original Equipment Manufacturer) that specializes in designing and
-manufacturing graphics tablets. Founded in 1996 and based in Taiwan, the
-company distributes their products across the USA, Europe, Japan, China
-and other places. The tablets designed by UC-Logic are sold by many
-companies, including Genius, Aiptek, Monoprice and many others.
+[KYE (KYE Systems Corporation)](http://www.kyecom.com/) is a DMS (design and
+manufacturing service) company specializing mostly in HID (Human
+Interface Device) devices, including graphics tablets. Established in
+1983 and based in Taiwan, the company sells graphics tablets under its
+[Genius](http://www.geniusnet.com/) brand name. Genius-branded tablets
+also include rebranded UC-Logic and Waltop tablets.
 
 ### Cooperation
 
-An attempt to contact UC-Logic was done in the beginning of 2012, using
-the "contact us" form on their web-site. A message was sent asking for
+An attempt to contact KYE was done in the beginning of 2012, using the
+"contact us" form on their web-site. A message was sent asking for
 tablet samples and information. As of March 2012 no reply was received.
 
-Waltop International Corporation
---------------------------------
-
-[Waltop International Corporation](http://www.waltop.com/) is an OEM
-(Original Equipment Manufacturer) that specializes in designing and
-manufacturing graphics tablets. The company was founded in 2004 and is
-based in Taiwan. The tablets designed by Waltop are sold by many
-companies, including Genius, Trust, Aiptek, and many others.
-
-### Cooperation
-
-The DIGI*mend* project has contacted Waltop in the beginning of 2012 and
-the company agreed to provide tablet samples and information. So far two
-samples were received with possibly more to come.
-
-Definitions
-===========
-
-Lines per inch
---------------
+LPI
+---
 
 Lines per inch (LPI) is a unit used to measure tablet pen coordinate
 sensing resolution. It represents the number of distinct pen positions a
 tablet working area is able to sense within one inch in either
-direction. Higher LPI along with higher RPS allow more
+direction. Higher LPI along with higher [RPS](#rps) allow more
 precise following of the pen movement and thus, smoother curves.
 
 The tablets have the same resolution in either direction. However, [some
@@ -89,8 +53,8 @@ of them](/tablets "Waltop Media Tablet 14.1") may limit pen coordinates
 to some number in both directions in compatibility modes, resulting in
 different resolutions.
 
-Pressure levels
----------------
+PL
+--
 
 Pressure levels (PL) is a number of distinct tip pressure force levels a
 tablet pen is able to detect between no pressure and maximum detectable
@@ -122,15 +86,46 @@ name. If someone confirms the guess, the mark is removed. If the guess
 is disproved, the tablet is removed from the "sold as" list and then, if
 the correct original model becomes known, added to the appropriate one.
 
-Reports per second
-------------------
+RPS
+---
 
-Reports per second (RPS) is a measure of tablet pen position report
+RPS (Reports per second) is a measure of tablet pen position report
 rate. It represents the number of pen position reports a tablet is able
 to send to the host PC per second.
 
-Higher RPS along with higher LPI allow more precise
+Higher RPS along with higher [LPI](#lpi) allow more precise
 following of the pen movement and thus, smoother curves. However, high
 RPS means more data to process in a unit of time and may result in
 drawing lag on low performance PCs running heavy-weight drawing
 applications.
+
+UC-Logic
+--------
+
+[UC-Logic (UC-Logic Technology Corporation)](http://www.uc-logic.com/) is an OEM
+(Original Equipment Manufacturer) that specializes in designing and
+manufacturing graphics tablets. Founded in 1996 and based in Taiwan, the
+company distributes their products across the USA, Europe, Japan, China
+and other places. The tablets designed by UC-Logic are sold by many
+companies, including Genius, Aiptek, Monoprice and many others.
+
+### Cooperation
+
+An attempt to contact UC-Logic was done in the beginning of 2012, using
+the "contact us" form on their web-site. A message was sent asking for
+tablet samples and information. As of March 2012 no reply was received.
+
+Waltop
+------
+
+[Waltop (Waltop International Corporation)](http://www.waltop.com/) is an OEM
+(Original Equipment Manufacturer) that specializes in designing and
+manufacturing graphics tablets. The company was founded in 2004 and is
+based in Taiwan. The tablets designed by Waltop are sold by many
+companies, including Genius, Trust, Aiptek, and many others.
+
+### Cooperation
+
+The DIGI*mend* project has contacted Waltop in the beginning of 2012 and
+the company agreed to provide tablet samples and information. So far two
+samples were received with possibly more to come.


### PR DESCRIPTION
I used the mediawiki files you you provided and compiled a vocabulary page. Note the second commit where I modify _includes/tablet.html is untested because I wasn't positive how to effectively test it. I included it in a separate commit for ease of rolling back. You can preview the vocabulary page at http://ademan.github.io/digimend.github.io/support/misc/vocabulary/ (with completely broken CSS however).
