### PR TITLE
Update driver digimend-kernel-drivers URL to v9

### DIFF
--- a/drivers/index.md
+++ b/drivers/index.md
@@ -16,11 +16,11 @@ driver package][11]. It works on v3.5 and later kernels and [supports a
 variety of tablets](/drivers/digimend/tablets/).
 
 Latest release
-: [digimend-kernel-drivers v8][19] - Jul 14, 2018
+: [digimend-kernel-drivers v9][19] - Dec 15, 2018
 
 [11]: https://github.com/DIGImend/digimend-kernel-drivers
 [12]: https://github.com/DIGImend/digimend-kernel-drivers/blob/master/README.md
-[19]: https://github.com/DIGImend/digimend-kernel-drivers/releases/tag/v8
+[19]: https://github.com/DIGImend/digimend-kernel-drivers/releases/tag/v9
 
 digimend-kernel-patches
 ----------------------


### PR DESCRIPTION
This PR simply update web site digimend-kernel-drivers URL to v9.